### PR TITLE
Add support for multiple image uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,15 @@ doSomethingWithResponse(response);
 
 ```
 
+### uploadMultiple
+Supports uploading an array of files/images at once from a single directory.
+
+```
+const response = await photos.mediaItems.upload(albumId, files, directoryPath, description);
+doSomethingWithResponse(response);
+
+```
+
 ### search
 
 A search can either fetch the contents of an album or search with filters. Either way default page

--- a/README.md
+++ b/README.md
@@ -157,10 +157,15 @@ doSomethingWithResponse(response);
 ```
 
 ### uploadMultiple
-Supports uploading an array of files/images at once from a single directory.
+Supports uploading an array of file objects at once from a single directory, file descriptions are optional. 
+Limited to 50 files, use multiple sequential calls to avoid this limitation. 
 
 ```
-const response = await photos.mediaItems.upload(albumId, files, directoryPath, description);
+const files = [
+  { name: 'myself.jpg', description: 'any description you want' },
+  { name: 'someone-else.png' }
+]
+const response = await photos.mediaItems.upload(albumId, files, directoryPath);
 doSomethingWithResponse(response);
 
 ```

--- a/lib/media_items/index.js
+++ b/lib/media_items/index.js
@@ -25,12 +25,17 @@ class MediaItems {
     })
   }
 
-  async uploadMultiple(albumId, files, directoryPath, description) {
+  async uploadMultiple(albumId, files, directoryPath) {
+    if(files.length > 50) {
+      throw new Error(`:batchCreate restricts maximum media items to 50. 
+        Make multiple sequential calls to uploadMultiple to avoid this limitation. 
+        See: https://developers.google.com/photos/library/guides/upload-media`)
+    }
     const url = `${constants.BASE_PATH}/:batchCreate`
     const newMediaItems = await Promise.all(files.map(async (file) => {
-      let token = await this.transport.upload(file, path.join(directoryPath, file))
+      let token = await this.transport.upload(file.name, path.join(directoryPath, file.name))
       return {
-        description: description || "",
+        description: file.description || "",
         simpleMediaItem: {
           uploadToken: token
         }

--- a/lib/media_items/index.js
+++ b/lib/media_items/index.js
@@ -1,6 +1,7 @@
 'use strict';
-
+const path = require('path');
 const constants = require('../../constants/media_items');
+
 
 class MediaItems {
   constructor(transport) {
@@ -13,16 +14,33 @@ class MediaItems {
 
   async upload(albumId, fileName, filePath, description) {
     let url = `${constants.BASE_PATH}/:batchCreate`
-    let token = await this.transport.upload(fileName, filePath)
-    return this.transport.post(url, {
-      albumId: albumId || "",
-      newMediaItems: [{
+    if(Array.isArray(fileName)){
+      let newMediaItems = await Promise.all(fileName.map(async (file) => {
+        let token = await this.transport.upload(file, path.join(filePath, file))
+        return {
+          description: description || "",
+          simpleMediaItem: {
+            uploadToken: token
+          }
+        }
+      }))
+      return this.transport.post(url, {
+        albumId: albumId || "",
+        newMediaItems
+      })
+    } else {
+      let token = await this.transport.upload(fileName, path.join(filePath, file))
+      let newMediaItems = [{
         description: description || "",
         simpleMediaItem: {
           uploadToken: token
         }
       }]
-    })
+      return this.transport.post(url, {
+        albumId: albumId || "",
+        newMediaItems
+      })
+    }
   }
 
   search(albumIdOrFilters, pageSize = 50, pageToken) {

--- a/lib/media_items/index.js
+++ b/lib/media_items/index.js
@@ -1,7 +1,6 @@
 'use strict';
-const path = require('path');
-const constants = require('../../constants/media_items');
 
+const constants = require('../../constants/media_items');
 
 class MediaItems {
   constructor(transport) {
@@ -14,33 +13,33 @@ class MediaItems {
 
   async upload(albumId, fileName, filePath, description) {
     let url = `${constants.BASE_PATH}/:batchCreate`
-    if(Array.isArray(fileName)){
-      let newMediaItems = await Promise.all(fileName.map(async (file) => {
-        let token = await this.transport.upload(file, path.join(filePath, file))
-        return {
-          description: description || "",
-          simpleMediaItem: {
-            uploadToken: token
-          }
-        }
-      }))
-      return this.transport.post(url, {
-        albumId: albumId || "",
-        newMediaItems
-      })
-    } else {
-      let token = await this.transport.upload(fileName, path.join(filePath, file))
-      let newMediaItems = [{
+    let token = await this.transport.upload(fileName, filePath)
+    return this.transport.post(url, {
+      albumId: albumId || "",
+      newMediaItems: [{
         description: description || "",
         simpleMediaItem: {
           uploadToken: token
         }
       }]
-      return this.transport.post(url, {
-        albumId: albumId || "",
-        newMediaItems
-      })
-    }
+    })
+  }
+
+  async uploadMultiple(albumId, files, directoryPath, description) {
+    const url = `${constants.BASE_PATH}/:batchCreate`
+    const newMediaItems = await Promise.all(files.map(async (file) => {
+      let token = await this.transport.upload(file, path.join(directoryPath, file))
+      return {
+        description: description || "",
+        simpleMediaItem: {
+          uploadToken: token
+        }
+      }
+    }))
+    return this.transport.post(url, {
+      albumId: albumId || "",
+      newMediaItems
+    })
   }
 
   search(albumIdOrFilters, pageSize = 50, pageToken) {


### PR DESCRIPTION
# Motivation
I wanted to upload many images at once, but making multiple requests to :batchCreate is not recommended (by google) and will be throttled so it would fail after about 25 images. info found at: https://developers.google.com/photos/library/guides/upload-media

# Description
I added a new function called uploadMultiple that supports multiple file uploads using a single batchCreate request as per googles suggested documentation

# Caveat(?)
while this is a better method then calling batchCreate many times, its capped at 50 files per call to batchCreate. I can include a check for 50+ files and warn the user in the event that is an issue.