### PR TITLE
Fix missing path dependency

### DIFF
--- a/lib/media_items/index.js
+++ b/lib/media_items/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const path = require('path');
 const constants = require('../../constants/media_items');
 
 class MediaItems {


### PR DESCRIPTION
## Description 
The code i added last week relies on node's `path`. I left it out by accident. My apologies.

