### PR TITLE
Add list method for mediaItems

### DIFF
--- a/lib/media_items/index.js
+++ b/lib/media_items/index.js
@@ -9,6 +9,14 @@ class MediaItems {
     this.transport = transport;
   }
 
+  list(pageSize = 50, pageToken) {
+    const params = {pageSize};
+    if (pageToken) {
+      params.pageToken = pageToken;
+    }
+    return this.transport.get(constants.BASE_PATH, params);
+  }
+
   get(mediaItemId) {
     return this.transport.get(`${constants.BASE_PATH}/${mediaItemId}`);
   }


### PR DESCRIPTION
Add missing method for getting a list of media items.

https://developers.google.com/photos/library/reference/rest/v1/mediaItems/list

Tested it locally and it worked fine.