### PR TITLE
Add method for changing Ky upload timeout

### DIFF
--- a/lib/media_items/index.js
+++ b/lib/media_items/index.js
@@ -21,9 +21,17 @@ class MediaItems {
     return this.transport.get(`${constants.BASE_PATH}/${mediaItemId}`);
   }
 
-  async upload(albumId, fileName, filePath, description) {
+  async upload(
+    albumId,
+    fileName,
+    filePath,
+    description,
+    requestTimeout = 10000
+  ) {
     const url = `${constants.BASE_PATH}/:batchCreate`;
-    const token = await this.transport.upload(fileName, filePath);
+    const token = await this.transport.upload(
+      fileName, filePath, requestTimeout);
+
     return this.transport.post(url, {
       albumId: albumId || '',
       newMediaItems: [
@@ -37,7 +45,13 @@ class MediaItems {
     });
   }
 
-  async uploadMultiple(albumId, files, directoryPath, requestDelay = 10000) {
+  async uploadMultiple(
+    albumId,
+    files,
+    directoryPath,
+    requestDelay = 10000,
+    requestTimeout = 10000
+  ) {
     const url = `${constants.BASE_PATH}/:batchCreate`;
     const batchedFiles = chunk(files, 50);
     // eslint-disable-next-line
@@ -45,7 +59,9 @@ class MediaItems {
       // eslint-disable-next-line
       const newMediaItems = await Promise.all(
         batch.map(async (file) => {
-          const token = await this.transport.upload(file.name, path.join(directoryPath, file.name));
+          const token = await this.transport.upload(
+            file.name, path.join(directoryPath, file.name), requestTimeout);
+
           return {
             description: file.description || '',
             simpleMediaItem: {

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -11,7 +11,6 @@ const ky = require('ky-universal').create({
 class Transport {
   constructor(authToken) {
     this.authToken = authToken;
-    this.timeout = 10000;
   }
 
   get(endpoint, params) {
@@ -21,7 +20,7 @@ class Transport {
     }).json();
   }
 
-  upload(fileName, filePath) {
+  upload(fileName, filePath, requestTimeout) {
     return ky
       .post('v1/uploads', {
         headers: {
@@ -31,7 +30,7 @@ class Transport {
           'X-Goog-Upload-Protocol': 'raw',
         },
         body: fs.readFileSync(filePath),
-        timeout: this.timeout,
+        timeout: requestTimeout,
       })
       .text();
   }
@@ -43,10 +42,6 @@ class Transport {
         json: params,
       })
       .json();
-  }
-
-  setUploadTimeout(timeout) {
-    this.timeout = timeout;
   }
 
   _getHeaders() {

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -11,6 +11,7 @@ const ky = require('ky-universal').create({
 class Transport {
   constructor(authToken) {
     this.authToken = authToken;
+    this.timeout = 10000;
   }
 
   get(endpoint, params) {
@@ -30,6 +31,7 @@ class Transport {
           'X-Goog-Upload-Protocol': 'raw',
         },
         body: fs.readFileSync(filePath),
+        timeout: this.timeout,
       })
       .text();
   }
@@ -41,6 +43,10 @@ class Transport {
         json: params,
       })
       .json();
+  }
+
+  setUploadTimeout(timeout) {
+    this.timeout = timeout;
   }
 
   _getHeaders() {


### PR DESCRIPTION
Added a method for changing Ky's upload timeout to, for example, be fair to slower connections that might take longer than the timeout to upload the file.

I also did the same for `uploadMultiple()`, it only needs the last argument.

Started in #39.

Example of usage, setting Ky's upload timeout to 15000 for a single upload: 

```js
await photos.mediaItems.upload(
  albumID, type, ".tempfile", type, 15000);
```