### PR TITLE
fixed readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ const files = [
 
 const requestDelay = 1000;
 
-const response = await photos.mediaItems.upload(albumId, files, directoryPath, requestDelay);
+const response = await photos.mediaItems.uploadMultiple(albumId, files, directoryPath, requestDelay);
 // doSomethingWithResponse(response);
 ```
 


### PR DESCRIPTION
#58  About this pull request

Edit *readme* file changing the function name to call when you want to upload multiple photos

from :
```js
const response = await photos.mediaItems.upload(albumId, files, directoryPath, requestDelay);
```
to:
```js
const response = await photos.mediaItems.uploadMultiple(albumId, files, directoryPath, requestDelay);
```